### PR TITLE
Add a simple insecure email (no password) auth provider for trial purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/authentication/README.md
+++ b/authentication/README.md
@@ -1,0 +1,37 @@
+## Flux Authentication Guide
+
+By default, Flux ships with a very simple, insecure identity workflow. A user can "login" to Flux by providing an email address. This email address serves as their identity for their session while making posts and comments. However there is no password or email verification, meaning anyone else can also do the same with the same email.
+
+This design is intentional and the only purpose is to allow you and a small team to quickly assess Flux as a product. **Please do not use Flux for confidential, collaborative efforts without first providing your own trusted authentication system.**
+
+### next-auth
+
+Flux is written in NextJS and therefore can benefit from the power of [next-auth](https://next-auth.js.org/). `next-auth` will enable you to provide your own authentication solution(s), you can check out all the supported providers [here](https://next-auth.js.org/configuration/providers).
+
+### Configuring your own Provider
+
+After reading the documentation provided by `next-auth` and once you have decided on which provider(s) you will use, it's time to configure.
+
+#### Remove the default credentials provider
+
+As mentioned above, the default authentication is insecure, it should not even be exposed as an option. The first thing you'll want to do is go to the [API routes file](../pages/api/[...nextauth].js) and remove the `Credentials` provider found there.
+
+#### Add your own provider.
+
+In the same routes file is where you will add your provider(s). Follow the official `next-auth` docs for your chosen provider, or create your own.
+
+#### Create your login form component
+
+The last step is to expose your auth provider to your users by creating the UI form for it. This can be done in 2 steps.
+
+1. In the [authentication/components directory](./authentication/components) add a NextJs component for your provider. It is suggested to copy the existing [provider](./authentication/components/NoAuthEmail.js) and work off of that example. This component should contain the UI and actions required for the style of auth you are performing.
+
+_example1: For the NoAuthEmail provider, a simple email input is exposed and on submit a signIn('credentials') action is fired based off next-auth docs._ _example2: For a Google OAuth provider, you would want to expose a button that when clicked fires a signIn('google') action._
+
+2. Lastly, export the provider component you made in this [file](./components/index.js).
+
+Once complete, the login page will pick up on all provider components in the [authentication/components](./authentication/components) directory and render them.
+
+### Conclusion
+
+We are continuing to work to make configuring authentication simpler. Flux is an open source project and we would appreciate helpful updates to the guide and examples to help others.

--- a/authentication/components/Google.js
+++ b/authentication/components/Google.js
@@ -1,0 +1,60 @@
+import { signIn } from 'next-auth/client';
+import styled from '@emotion/styled';
+import { Icon } from 'pageUtils/post/atoms';
+
+const AuthButtonContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  width: 100%;
+  max-width: 480px;
+  margin-top: 2em;
+`;
+
+const AuthButton = styled.button`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  border: 1px solid white;
+  background-color: #060a0c;
+  border-radius: 99px;
+  padding: 16px;
+  outline: unset;
+  box-shadow: var(--shadow);
+  transition: all 300ms;
+  color: white;
+
+  &:hover {
+    transform: scale(0.99);
+  }
+
+  &:active {
+    transform: scale(0.97);
+  }
+
+  > ${Icon} {
+    background: white;
+  }
+
+  > span {
+    border-left: 1px solid var(--accent);
+    padding: 0 8px;
+    margin-left: 8px;
+    text-transform: uppercase;
+  }
+`;
+
+export default function Google() {
+  const handleLogin = () => {
+    signIn('google', { callbackUrl: '/' });
+  };
+
+  return (
+    <AuthButtonContainer>
+      <AuthButton onClick={handleLogin}>
+        <Icon className="icon-google"></Icon>
+        <span>Login With Google</span>
+      </AuthButton>
+    </AuthButtonContainer>
+  );
+}

--- a/authentication/components/NoAuthEmail.js
+++ b/authentication/components/NoAuthEmail.js
@@ -1,0 +1,80 @@
+import { signIn } from 'next-auth/client';
+import styled from '@emotion/styled';
+import { ButtonTertiary } from 'components/Button';
+
+const AuthContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  width: 100%;
+  max-width: 480px;
+  margin-top: 2em;
+`;
+
+const FormWrapper = styled.div`
+  align-items: center;
+  border: 1px solid white;
+  background-color: #060a0c;
+  border-radius: 16px;
+  padding: 16px;
+  outline: unset;
+  box-shadow: var(--shadow);
+  color: white;
+
+  div.title {
+    text-align: center;
+    text-transform: uppercase;
+  }
+  div.info {
+    margin-top: 16px;
+    font-size: 0.75rem;
+  }
+
+  form {
+    input {
+      margin: 16px 0px;
+      width: 100%;
+      padding: 12px 8px;
+    }
+
+    button {
+      margin-left: auto;
+      box-sizing: inherit;
+      width: 100%;
+      justify-content: center;
+    }
+  }
+`;
+
+export default function NoAuthEmail() {
+  const handleLogin = event => {
+    event.preventDefault();
+
+    signIn('credentials', { email: event.target.email.value });
+  };
+
+  return (
+    <AuthContainer>
+      <FormWrapper>
+        <div className="title">
+          <span>Login/Sign Up With Email</span>
+        </div>
+        <form onSubmit={handleLogin}>
+          <input id="email" type="email" required placeholder="Email" />
+          <ButtonTertiary type="submit">Login/Sign Up</ButtonTertiary>
+        </form>
+        <div className="info">
+          Please note this login process does not perform any authentication or
+          verification of identity and is purely for trial purposes. You will
+          assume the identify of the email you provide, as will any other user.
+          For use in any sensitive or collaborative application please apply
+          your own authentication following this{' '}
+          <a href="https://github.com/planetscale/flux/blob/main/authentication/README.md">
+            guide
+          </a>
+          .
+        </div>
+      </FormWrapper>
+    </AuthContainer>
+  );
+}

--- a/authentication/components/index.js
+++ b/authentication/components/index.js
@@ -1,0 +1,2 @@
+export { default as Google } from './Google';
+export { default as NoAuthEmail } from './NoAuthEmail';

--- a/components/CreateOrg/index.js
+++ b/components/CreateOrg/index.js
@@ -5,7 +5,6 @@ import { useImmer } from 'use-immer';
 import { useRouter } from 'next/router';
 import { ButtonWireframe } from 'components/Button';
 import { useUserActions } from 'state/user';
-import { signOut } from 'next-auth/client';
 
 const Wrapper = styled.div`
   width: 100%;
@@ -13,15 +12,21 @@ const Wrapper = styled.div`
   height: fit-content;
   border-radius: 4px;
   box-shadow: var(--shadow);
+  background-color: var(--background);
 
   ${media.phone`
     border-radius: 0;
   `}
+
+  .profile-header {
+    padding: 32px;
+    font-weight: bold;
+    font-size: 2rem;
+  }
 `;
 
 const FormLabel = styled.div`
   padding: 2em;
-  background-color: var(--background);
   border-bottom: 1px solid var(--accent2);
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
@@ -40,7 +45,6 @@ const FormLabelOrganization = styled.div`
 
 const InputWrapper = styled.div`
   position: relative;
-  background-color: var(--background);
   color: var(--text);
   border-bottom: 1px solid var(--accent2);
   padding: 32px;
@@ -91,7 +95,6 @@ const InputWrapper = styled.div`
 `;
 
 const ButtonWrapper = styled.div`
-  background-color: var(--background);
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
   padding: 32px;
@@ -177,6 +180,7 @@ export default function CreateOrg({ name, email, avatar }) {
 
   return (
     <Wrapper>
+      <div className="profile-header">User Profile</div>
       {state.orgName && (
         <FormLabel>
           <FormLabelIdentifier>Create Account In</FormLabelIdentifier>

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -8,9 +8,26 @@ export default NextAuth({
       clientId: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
       state: false,
+      pages: {
+        signIn: '/',
+        signOut: '/',
+      },
+    }),
+    Providers.Credentials({
+      name: 'NoAuthEmail',
+      credentials: {
+        username: { label: 'Email', type: 'text', placeholder: 'jsmith' },
+      },
+      async authorize(credentials) {
+        return credentials.email ? { email: credentials.email } : null;
+      },
     }),
     // ...add more providers here
   ],
+  pages: {
+    signIn: '/',
+    signOut: '/',
+  },
   session: {
     jwt: true,
   },

--- a/pages/api/create-user.js
+++ b/pages/api/create-user.js
@@ -21,14 +21,14 @@ export default async (req, res) => {
     User
         (email, username, displayName, role, orgId)
     VALUES
-        (?, ?, ?, ?, (SELECT id FROM Org WHERE name = ? LIMIT 1))
+        (?, ?, ?, ?, ?)
   `;
   await connection.execute(userQuery, [
     user.email,
     userName,
     displayName,
     'USER',
-    orgName,
+    1, // TODO: There is only one org so hard coding it as the org id when creating users
   ]);
 
   const idQuery = `SELECT id FROM User WHERE id = LAST_INSERT_ID()`;

--- a/pages/login/index.js
+++ b/pages/login/index.js
@@ -4,9 +4,9 @@ import CreateOrg from 'components/CreateOrg';
 import { useUserContext, useUserActions } from 'state/user';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { Icon } from 'pageUtils/post/atoms';
 import CustomLayout from 'components/CustomLayout';
-import { signIn, useSession } from 'next-auth/client';
+import { providers, useSession } from 'next-auth/client';
+import * as AuthProviderLogins from 'authentication/components/';
 
 const Wrapper = styled.div`
   display: flex;
@@ -43,49 +43,7 @@ const Logo = styled.img`
   max-width: 260px;
 `;
 
-const AuthButtonContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  width: 100%;
-  max-width: 480px;
-  margin-top: 2em;
-`;
-
-const AuthButton = styled.button`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  border: 1px solid white;
-  background-color: #060a0c;
-  border-radius: 99px;
-  padding: 16px;
-  outline: unset;
-  box-shadow: var(--shadow);
-  transition: all 300ms;
-  color: white;
-
-  &:hover {
-    transform: scale(0.99);
-  }
-
-  &:active {
-    transform: scale(0.97);
-  }
-
-  > ${Icon} {
-    background: white;
-  }
-
-  > span {
-    border-left: 1px solid var(--accent);
-    padding: 0 8px;
-    margin-left: 8px;
-    text-transform: uppercase;
-  }
-`;
-
-export default function Login() {
+export default function Login({ providers }) {
   const { user, loaded, isLoading } = useUserContext();
 
   const { getUser } = useUserActions();
@@ -102,11 +60,7 @@ export default function Login() {
     if (session && !loading && !isLoading) {
       getUser();
     }
-  }, [session]);
-
-  const handleLogin = () => {
-    signIn('google', { callbackUrl: '/' });
-  };
+  }, [session, loading]);
 
   return (
     <CustomLayout>
@@ -115,12 +69,10 @@ export default function Login() {
           {!session && (
             <LogoContainer>
               <Logo src="/logo_flux.svg" alt="Flux logo"></Logo>
-              <AuthButtonContainer>
-                <AuthButton onClick={handleLogin}>
-                  <Icon className="icon-google"></Icon>
-                  <span>Login With Google</span>
-                </AuthButton>
-              </AuthButtonContainer>
+              {Object.values(providers).map(provider => {
+                const AuthLogin = AuthProviderLogins[provider.name];
+                return <AuthLogin key={provider.name} />;
+              })}
             </LogoContainer>
           )}
           {session && !loading && loaded && !user?.org && (
@@ -135,3 +87,9 @@ export default function Login() {
     </CustomLayout>
   );
 }
+
+Login.getInitialProps = async () => {
+  return {
+    providers: await providers(),
+  };
+};


### PR DESCRIPTION
In our current system we would require a user who is spinning up Flux to either go and create a Google auth project or understand how our auth works and provider their own before being able to test the product.

What we want is an easy way for someone to evaluate the product. The problem being that without a massive refactor we still need a way to identify users.

This PR introduces an auth provider using `next-auth` that simply accepts an email address and you are granted access to flux.  Of course this is highly insecure, so much so that someone could certainly create a user and impersonate someone else.  That is why we need to be very clear not to use this in any production capacity.

I have added a warning to the login page itself (only when this particular provider is in use) as well a decent (i hope ot improve it in the future) README.

![image](https://user-images.githubusercontent.com/5255924/111705159-aa22d680-8816-11eb-88f3-20b8c37bd30f.png)

I intend to remove the google auth as an option soon. Perhaps we can convert it to some kind of example.