### PR TITLE
Fix close icon padding for notification item

### DIFF
--- a/components/Notifications/index.js
+++ b/components/Notifications/index.js
@@ -74,7 +74,7 @@ const HoverIcon = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 6px 8px 4px;
+  padding: 6px 8px;
   border-radius: var(--border-radius);
 
   > svg {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/623670/112554708-05f3df00-8d84-11eb-8c0f-fa3cf452088b.png)
