### PR TITLE
Add bottom margin to not(last-of-type) paragraphs

### DIFF
--- a/pageUtils/post/styles.js
+++ b/pageUtils/post/styles.js
@@ -150,6 +150,8 @@ const ReplyContainer = styled.div`
   display: flex;
   flex-direction: column;
   margin: 2em 0;
+  position: sticky;
+  bottom: 2em;
 
   ${media.phone`
     padding: 42px;

--- a/pages/styles.css
+++ b/pages/styles.css
@@ -26,6 +26,10 @@ button {
 
 p {
   overflow-wrap: break-word;
+
+  &:not(:last-of-type) {
+    margin-bottom: 1em !important;
+  }
 }
 
 a,


### PR DESCRIPTION
* This is to avoid line breaks as paragraph dividers
* Line breaks are rendered as empty paras by the editor

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/623670/113056632-e2081300-9160-11eb-9dae-edd3a4259fad.png)|![image](https://user-images.githubusercontent.com/623670/113056662-ed5b3e80-9160-11eb-8c37-546d68dcde98.png)|

